### PR TITLE
feat: Display hours in position and length

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,7 +203,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chcl_now_playing"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "chrono",
  "smol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chcl_now_playing"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [lib]

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -136,10 +136,18 @@ pub async fn wrt_refresh_thread(state: &smol::lock::Mutex<PluginState>) {
             }
 
             let pos = Duration::from_micros((timeline_properties.Position().unwrap_or_default().Duration / 10).try_into().unwrap()) + offset;
-            protected_set(&POSITION, Some(CString::new(format!("{}:{:02}", pos.as_secs() / 60, pos.as_secs() % 60)).unwrap_or(CString::new("CString::New failed on title").unwrap()))).await;
+            if pos.as_secs() >= 60 * 60 {
+                protected_set(&POSITION, Some(CString::new(format!("{}:{:02}:{:02}", pos.as_secs() / 60 / 60, pos.as_secs() / 60 % 60, pos.as_secs() % 60)).unwrap_or(CString::new("CString::New failed on title").unwrap()))).await;
+            } else {
+                protected_set(&POSITION, Some(CString::new(format!("{}:{:02}", pos.as_secs() / 60, pos.as_secs() % 60)).unwrap_or(CString::new("CString::New failed on title").unwrap()))).await;
+            }
             protected_set(&POSITION_I, Some(CString::new(pos.as_secs().to_string()).unwrap())).await;
             let len = Duration::from_micros((timeline_properties.EndTime().unwrap_or_default().Duration / 10).try_into().unwrap());
-            protected_set(&LENGTH, Some(CString::new(format!("{}:{:02}", len.as_secs() / 60, len.as_secs() % 60)).unwrap_or(CString::new("CString::New failed on title").unwrap()))).await;
+            if len.as_secs() >= 60 * 60 {
+                protected_set(&LENGTH, Some(CString::new(format!("{}:{:02}:{:02}", len.as_secs() / 60 / 60, len.as_secs() / 60 % 60, len.as_secs() % 60)).unwrap_or(CString::new("CString::New failed on title").unwrap()))).await;
+            } else {
+                protected_set(&LENGTH, Some(CString::new(format!("{}:{:02}", len.as_secs() / 60, len.as_secs() % 60)).unwrap_or(CString::new("CString::New failed on title").unwrap()))).await;
+            }
             protected_set(&LENGTH_I, Some(CString::new(len.as_secs().to_string()).unwrap())).await;
         } else {
             protected_set(&POSITION, None).await;


### PR DESCRIPTION
This merge request changes how position and length is displayed.

* If the position or length is equal to or over an hour it changes the format to `{}:{:2}:{:2}` and shows hours as hours.
* If it is under an hour it displays it in minutes and seconds like it did originally.

The reason for this merge request is that I wanted to be able to see hours as hours when watching a movie (or any other media that's longer than an hour)